### PR TITLE
updated boot2docker CLI version

### DIFF
--- a/lib/meta.js
+++ b/lib/meta.js
@@ -52,11 +52,11 @@ module.exports = {
     },
     win32: {
       b2d: 'https://github.com/boot2docker/windows-installer/releases/' +
-      'download/v1.6.0/docker-install.exe'
+      'download/v1.6.2/docker-install.exe'
     },
     darwin: {
       b2d: 'https://github.com/boot2docker/osx-installer/releases/download/' +
-      'v1.6.0/Boot2Docker-1.6.0.pkg'
+      'v1.6.2/Boot2Docker-1.6.2.pkg'
     }
   }
 };

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -48,7 +48,7 @@ module.exports = {
         }
       },
       b2d: 'https://github.com/boot2docker/boot2docker-cli/releases/download/' +
-        'v1.6.0/boot2docker-v1.6.0-linux-amd64'
+        'v1.6.2/boot2docker-v1.6.2-linux-amd64'
     },
     win32: {
       b2d: 'https://github.com/boot2docker/windows-installer/releases/' +


### PR DESCRIPTION
tested in an ubuntu 14.04 box. works fine.
Also, closes https://github.com/kalabox/kalabox/issues/186.
