### PR TITLE
Return STDIN to original state instead of terminate it

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -771,7 +771,7 @@ module.exports = function(kbox) {
           if (process.stdin.setRawMode) {
             process.stdin.setRawMode(false);
           }
-          process.stdin.destroy();
+          process.stdin.pause();
         });
         return stream;
       })


### PR DESCRIPTION
@bcauldwell, this seems to resolve the issue by setting `stdin` back to its original state. I am not sure if this has other implications for our other things. Thoughts?
