### PR TITLE
Check (and rebuild if necessary) that VB's kernel modules are loaded if kbox up fails

### DIFF
--- a/provider/b2d.js
+++ b/provider/b2d.js
@@ -22,6 +22,7 @@ module.exports = function(kbox) {
   var bin = require('./lib/bin.js')(kbox);
   var env = require('./lib/env.js')(kbox);
   var net = require('./lib/net.js')(kbox);
+  var meta = require('./../lib/meta.js');
 
   // Get boot2docker and ssh executable path.
   var B2D_EXECUTABLE = bin.getB2DExecutable();
@@ -166,8 +167,13 @@ module.exports = function(kbox) {
       // Log start.
       log.info(kbox.util.format('Bringing boot2docker up [%s].', counter));
 
+      // Check if VB's modules are loaded
+      return bin.sh('lsmod | grep -q "vboxdrva[^_-]"')
+
       // Run provider command.
-      return shProvider(['up'])
+      .then(function() {
+        shProvider(['up']);
+      })
 
       // Wrap errors.
       .catch(function(err) {
@@ -176,6 +182,8 @@ module.exports = function(kbox) {
       })
 
       .then(function(output) {
+        console.log('Foo :' + output);
+	//bin.sh('sudo ' + meta.PROVIDER_DOWNLOAD_URL.linux.vb['debian'].recompile)
 
         // If B2D reports no IP found we will try to set it manually
         // @todo: tighter check here

--- a/provider/b2d.js
+++ b/provider/b2d.js
@@ -176,7 +176,8 @@ module.exports = function(kbox) {
 
         .then(function(modulesAreUp) {
           if (!modulesAreUp) {
-            log.info('VirtualBox\'s kernel modules seem to be down. Trying to bring them up.', err);
+            log.info('VirtualBox\'s kernel modules seem to be down.' +
+                ' Trying to bring them up.', err);
             return bin.bringVBModulesUp();
           } else {
             // The problem was something else, let's just fail

--- a/provider/b2d.js
+++ b/provider/b2d.js
@@ -192,7 +192,7 @@ module.exports = function(kbox) {
           } else {
             throw new VError('VirtualBox\'s modules seem to be up. Retrying.');
           }
-        })
+        });
 
       })
 

--- a/provider/lib/bin.js
+++ b/provider/lib/bin.js
@@ -95,8 +95,54 @@ module.exports = function(kbox) {
 
   };
 
+  /*
+   * Check to see if we need to recompile VirtualBox's modules
+   */
+  var requiresKernelRecompile = function() {
+    if (kbox.install.linuxOsInfo.getFlavor() === 'debian') {
+
+      return sh('lsmod | grep -q "vboxdrv[^_-]"')
+
+      .catch(function(err) {
+        //console.log('catch: ' +err);
+        return Promise.resolve(true);
+      })
+
+      .then(function(err) {
+        if (err) {
+          return Promise.resolve(true);
+        } else {
+          //console.log('then: ' +err);
+	  return Promise.resolve(false);
+        }
+      })
+    }
+    else {
+      Promise.resolve(false);
+    }
+  };
+
+  /*
+   * Recompile VirtualBox's kernel modules
+   */
+  var rebuildKernel = function() {
+    var _sh = kbox.core.deps.get('shell');
+    //var cmd = getRecompileCommand();
+    var cmd = '/etc/init.d/vboxdrv start';
+    return Promise.fromNode(function(cb) {
+      _sh.execAdmin(cmd, cb);
+    })
+
+    // 
+    .catch(function(err) {
+      // check to see if recompiling kernel failz
+    })
+  };
+
   // Build module function.
   return {
+    requiresKernelRecompile: requiresKernelRecompile,
+    rebuildKernel: rebuildKernel,
     sh: sh,
     getB2DBinPath: getB2DBinPath,
     getB2DExecutable: getB2DExecutable,

--- a/provider/lib/bin.js
+++ b/provider/lib/bin.js
@@ -16,7 +16,7 @@ module.exports = function(kbox) {
 
   // Kalabox modules
   var Promise = kbox.Promise;
-  var meta = require('./meta.js');
+  var meta = require('../../lib/meta.js');
 
   /*
    * Get directory for provider executable.

--- a/provider/lib/bin.js
+++ b/provider/lib/bin.js
@@ -13,6 +13,7 @@ module.exports = function(kbox) {
 
   // NPM modules
   var VError = require('verror');
+  var _ = require('lodash');
 
   // Kalabox modules
   var Promise = kbox.Promise;
@@ -117,7 +118,7 @@ module.exports = function(kbox) {
         } else {
           return Promise.resolve(false);
         }
-      })
+      });
     } else {
       Promise.resolve(true);
     }
@@ -154,7 +155,7 @@ module.exports = function(kbox) {
         } else {
           return Promise.resolve(true);
         }
-    })
+    });
   };
 
   // Build module function.

--- a/provider/lib/bin.js
+++ b/provider/lib/bin.js
@@ -102,6 +102,7 @@ module.exports = function(kbox) {
   var checkVBModules = function() {
     if (kbox.install.linuxOsInfo.getFlavor() === 'debian') {
 
+      // This is how /etc/init.d/vboxdrv checks if the modules are loaded
       return sh('lsmod | grep -q "vboxdrv[^_-]"')
 
       // Exit status != 0, modules are not loaded
@@ -125,7 +126,8 @@ module.exports = function(kbox) {
   /*
    * Recompile VirtualBox's kernel modules
    * 
-   * @todo: @jeffesquivels - Try to load VirtualBox's kernel modules first
+   * @todo: @jeffesquivels - Try to load VirtualBox's kernel modules and only
+   * recompile if that fails 
    */
   var bringVBModulesUp = function() {
     var _sh = kbox.core.deps.get('shell');

--- a/provider/lib/bin.js
+++ b/provider/lib/bin.js
@@ -126,13 +126,14 @@ module.exports = function(kbox) {
 
   /*
    * Recompile VirtualBox's kernel modules
-   * 
+   *
    * @todo: @jeffesquivels - Try to load VirtualBox's kernel modules and only
-   * recompile if that fails 
+   * recompile if that fails
    */
   var bringVBModulesUp = function() {
     var _sh = kbox.core.deps.get('shell');
-    var cmd = meta.PROVIDER_DOWNLOAD_URL.linux.vb[kbox.install.linuxOsInfo.getFlavor()].recompile;
+    var flavor = kbox.install.linuxOsInfo.getFlavor();
+    var cmd = meta.PROVIDER_DOWNLOAD_URL.linux.vb[flavor].recompile;
 
     return Promise.fromNode(function(cb) {
       _sh.execAdmin(cmd, cb);
@@ -148,20 +149,20 @@ module.exports = function(kbox) {
     })
 
     .then(function(output) {
-        if (_.includes(output, 'wrong')) {
-          // Recompilation failed
-          log.info('The modules couldn\'t be compiled. Dying now.', output);
-          return Promise.resolve(false);
-        } else {
-          return Promise.resolve(true);
-        }
+      if (_.includes(output, 'wrong')) {
+        // Recompilation failed
+        log.info('The modules couldn\'t be compiled. Dying now.', output);
+        return Promise.resolve(false);
+      } else {
+        return Promise.resolve(true);
+      }
     });
   };
 
   // Build module function.
   return {
-    checkVBModules: checkVBModules,  
-    bringVBModulesUp: bringVBModulesUp,  
+    checkVBModules: checkVBModules,
+    bringVBModulesUp: bringVBModulesUp,
     sh: sh,
     getB2DBinPath: getB2DBinPath,
     getB2DExecutable: getB2DExecutable,


### PR DESCRIPTION
This is the initial code to fix #640. I'm opening the PR now in case someone wants to chime in and suggest code or solution design improvements.

Right now it should work for Debian-based distros (I'm installing Fedora on an spare machine to solve for that too, now that it's officially supported by Kalabox).

There's still some optimizations I would like to make (for example, trying to load the modules and see if that works before recompiling them, which takes more time a resources).

Also, this should have more testing as I replicated the environment of people having the issues by `sudo /etc/init.d/vboxdrv stop` but there may be some differences between that and not having the modules at all (which is the real issue).
